### PR TITLE
README.md: add alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Personal mail server for a single user or a small family. Written in pure python with [minimal dependencies](Pipfile).
 Designed for dynamic alias based workflow where a different alias is used for each purpose.
 
-# Getting started
+## Getting started
 
  1. Get a domain name
  1. Get a VPS (or a home server). Setup firewall rules for receive on port 25, 995, 465
@@ -13,7 +13,7 @@ Designed for dynamic alias based workflow where a different alias is used for ea
  1. Run `./mail4one.pyz -c config.json`
  1. Setup systemd service and TLS certificates. See [deploy_configs](deploy_configs/) for examples
 
-# Sending email
+## Sending email
 
 Mail4one only takes care of receiving and serving email. For sending email, use an external service like below
 
@@ -25,17 +25,17 @@ Most of them have generous free tier which is more than enough for personal use.
 
 Sending email is tricky. Even if everything is correctly setup (DMARC, DKIM, SPF), popular email vendors like google, microsoft may mark emails sent from your IP as spam for no reason. Hence using a dedicated service is the only reliable way to send emails.
 
-# Community
+## Community
 
 Original source is at https://gitea.balki.me/balki/mail4one
 
 For issues, pull requests, discussions, please use github mirror: https://github.com/mail4one/mail4one
 
-# Documentation
+## Documentation
 
 See files under [deploy_configs](deploy_configs/) for configuring and deploying to a standard systemd based linux system (e.g. debian, ubuntu, fedora, archlinux etc). [config.sample](deploy_configs/config.sample) has inline comments for more details. Feel free create github issue/discussions for support.
 
-## DNS Records (Receiving)
+### DNS Records (Receiving)
 
 If you want to receive email for `john@example.com` and your VPS IP address is `1.2.3.4`. Following record needs to be created
 
@@ -56,7 +56,7 @@ Make sure to have make, git, python >= 3.9, and pip installed in your system and
 
 This should generate `mail4one.pyz` in current folder. This is a [executable python archive](https://docs.python.org/3/library/zipapp.html). Should be runnable as `./mail4one.pyz` or as `python3 mail4one.pyz`.
 
-# Roadmap (Planned features for future)
+## Roadmap (Planned features for future)
 
 * Other ways to install and update (PIP, AUR, docker etc)
 * Write dedicated documentation
@@ -68,3 +68,10 @@ This should generate `mail4one.pyz` in current folder. This is a [executable pyt
 * Optional DMARC,SPF,DKIM verification
 * Webmail Client
 * Web UI to view graphs and smart reports
+
+## Alternatives
+
+* [Awesome Selhosted: Email](https://github.com/awesome-selfhosted/awesome-selfhosted?tab=readme-ov-file#communication---email---complete-solutions)
+* [Awesome Email](https://github.com/Mindbaz/awesome-opensource-email)
+* [chatmail](https://delta.chat/en/chatmail) - a Postfix + Dovecot solution optimized for Delta Chat
+* [EmailRelay](https://emailrelay.sourceforge.net/) - a small SMTP and POP3 server that is easy to configure. You can install it on an OpenWrt router and configure with `lici-app-email` 


### PR DESCRIPTION
It would be great to help a user to find a best solution that feet his needs. So please add the alternatives section to make the process easier.
Also I changed headers from H1 to H2.

I really like your idea to make a small SMTP for a family needs. I also working in this direction. There are many ready to use solutions like Mailcow or Emailwiz from Like Smith that install Postfix, Rouncube webmail and add some admin GUI. Usually they are quite heavy but works on a Raspberry without problems.

Instead I'll try to use the cheapest OpenWrt routers and run a mail server right on them. There is an [EmailRelay](https://emailrelay.sourceforge.net/) server that is small but can be easily configured unlike the Postfix. So I created a GUI for the Luci admin panel which allows to configure the EmailRelay.
I hope this may be interesting for you too.
The whole picture and challenges I tried to collect here https://github.com/yurt-page/docs/blob/main/email.md
